### PR TITLE
Updating the spock-core to the final version

### DIFF
--- a/specs/build.gradle
+++ b/specs/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.5:indy'
-    compile 'org.spockframework:spock-core:1.1-groovy-2.4-SNAPSHOT'
+    compile 'org.spockframework:spock-core:1.1-groovy-2.4'
     compile 'com.electriccloud:ec-specs-plugins-core:1.9.1'
     compile 'com.jayway.restassured:rest-assured:2.4.0'
     compile 'org.apache.ant:ant:1.9.4'


### PR DESCRIPTION
instead of snapshot.
Based on similar change in EC-RemoteAccess as reference. See https://github.com/electric-cloud/EC-RemoteAccess/commit/5d10c0521dfddc920f412048c005ebc3768e6c15